### PR TITLE
Remove verbiage about SQL Server backup from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ In development, not usable yet.
 ###Project Layout
 
 BlueHarvest.NET - A .NET based ASP.NET MVC and Web API application  
-Database - This contains the initial SQL Server db script as well as an
-SQL Server backup that also provides a database diagram.
+Database - This contains the initial SQL Server db script
 
 ###Development
 


### PR DESCRIPTION
- The SQL Server backup was scraped, it may return in the future but for now it's gone.